### PR TITLE
for kamailio-etcd-dispatcher updates dockerfile to be FROM current node version

### DIFF
--- a/high-availability/kamailio-etcd-dispatcher/Dockerfile
+++ b/high-availability/kamailio-etcd-dispatcher/Dockerfile
@@ -3,10 +3,10 @@
 # Both announces and dispatches based on etcd.
 # ---------------------------------------------------
 
-FROM google/nodejs
+FROM node
 
 MAINTAINER Doug Smith <info@laboratoryb.org>
-ENV build_date 2014-12-19
+ENV build_date 2015-10-26
 
 RUN npm install -g kamailio-etcd-dispatcher
 


### PR DESCRIPTION
old base image was `google/nodejs` which is now deprecated. discovered while updating kamailio etcd dispatcher version