### PR TITLE
Fixes #62. Adds installation of `gettext`package

### DIFF
--- a/asterisk/13/Dockerfile
+++ b/asterisk/13/Dockerfile
@@ -4,7 +4,7 @@ ENV build_date 2016-05-15
 
 RUN yum update -y
 RUN yum install -y epel-release
-RUN yum install git kernel-headers gcc gcc-c++ cpp ncurses ncurses-devel libxml2 libxml2-devel sqlite sqlite-devel openssl-devel newt-devel kernel-devel libuuid-devel net-snmp-devel xinetd tar jansson-devel make bzip2 -y
+RUN yum install git kernel-headers gcc gcc-c++ cpp ncurses ncurses-devel libxml2 libxml2-devel sqlite sqlite-devel openssl-devel newt-devel kernel-devel libuuid-devel net-snmp-devel xinetd tar jansson-devel make bzip2 gettext -y
 
 WORKDIR /tmp
 # Get pj project

--- a/asterisk/14/Dockerfile
+++ b/asterisk/14/Dockerfile
@@ -30,6 +30,7 @@ RUN yum update -y && \
         libsrtp-devel \
         gsm-devel \
         speex-devel \
+        gettext \
         -y
 
 # Download asterisk.


### PR DESCRIPTION
This PR adds installation of `gettext`package in order to be able to use envsubst. This makes it possible use envsubst in Dockerfiles inheriting from `dougbtv/asterisk13`.

__Example__
```
FROM dougbtv/asterisk13:latest

ENV dbhost=mysql
ENV dbname=asterisk
ENV dbuser=root
ENV dbpass=
ENV dbport=3306

COPY config/res_mysql_template.con /etc/asterisk

CMD envsubst < /etc/asterisk/res_mysql_template.conf > /etc/asterisk/res_mysql.conf && asterisk -f
```